### PR TITLE
[DCB][OPS-12719] set test volumes

### DIFF
--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -18,7 +18,7 @@ journeys {
 
   refund-journey-individual = {
     description = "Refund Journey Individual"
-    load = 0.06
+    load = 0.5
     parts = [
       individual-refund-start
       refund-journey
@@ -27,7 +27,7 @@ journeys {
 
   refund-journey-agent = {
     description = "Refund Journey Agent"
-    load = 0.06
+    load = 0.5
     parts = [
       agent-refund-start
       refund-journey
@@ -36,7 +36,7 @@ journeys {
 
   tracker-journey = {
     description = "Tracker Journey"
-    load = 0.06
+    load = 0.5
     parts = [
       tracker-journey
     ]


### PR DESCRIPTION
- set journeys to total of 540 refund journeys in 10 minutes of testing, with 270 history journeys in same 10 minutes
- given 25k expected refund volumes in 25/26, this covers 2% concurrency, which is way above expectations
- numbers can be re-evaluated any time when we have live data
- this branch [has been run](https://performance.tools.staging.tax.service.gov.uk/job/self-assessment-refund-performance-tests/112/gatling/) and service seems robust at these numbers
- worth noting our frontend has only 1 instance in staging, but will have 2 in production as per [platform guidance](https://confluence.tools.tax.service.gov.uk/x/_SaPB)